### PR TITLE
Improves error message when applied to complex enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ syn = { version = "1.0", features = ["extra-traits"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 
+[dev-dependencies]
+trybuild = "1.0"
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,13 @@ pub fn arg_enum(items: proc_macro::TokenStream) -> proc_macro::TokenStream {
             let id = &item.ident;
             let lit: TokenTree = Literal::string(&id.to_string()).into();
             let mut all_lits = vec![(lit, id)];
-
+            if ! item.fields.is_empty() {
+                panic!(
+                    "Only enum with unit variants are supported! \n\
+                    Variant {}::{} is not an unit variant",
+                    name, &id.to_string()
+                );
+            }
             item.attrs
                 .iter()
                 .filter(|attr| attr.path.is_ident("arg_enum"))

--- a/tests/enums.rs
+++ b/tests/enums.rs
@@ -7,15 +7,6 @@ pub enum Foo {
     Baz,
 }
 
-// should fail to compile
-/*
-#[derive(ArgEnum)]
-pub enum Complex {
-    A,
-    B(Foo),
-    C{a: usize, b: usize},
-}
-*/
 
 #[test]
 fn parse() {
@@ -50,5 +41,14 @@ mod alias {
     #[test]
     fn variants() {
         assert_eq!(&Bar::variants(), &["A", "B", "C", "Cat"]);
+    }
+}
+
+mod ui {
+    #[test]
+    fn invalid_applications() {
+        let t = trybuild::TestCases::new();
+        t.compile_fail("tests/ui/complex-enum.rs");
+        t.compile_fail("tests/ui/derive-not-on-enum.rs");
     }
 }

--- a/tests/ui/complex-enum.rs
+++ b/tests/ui/complex-enum.rs
@@ -1,0 +1,15 @@
+use arg_enum_proc_macro::ArgEnum;
+
+
+pub enum Foo {
+    Bar,
+    /// Foo
+    Baz,
+}
+
+#[derive(ArgEnum)]
+pub enum Complex {
+    A,
+    B(Foo),
+    C{a: usize, b: usize},
+}

--- a/tests/ui/complex-enum.stderr
+++ b/tests/ui/complex-enum.stderr
@@ -1,0 +1,8 @@
+error: proc-macro derive panicked
+  --> $DIR/complex-enum.rs:10:10
+   |
+10 | #[derive(ArgEnum)]
+   |          ^^^^^^^
+   |
+   = help: message: Only enum with unit variants are supported! 
+           Variant Complex::B is not an unit variant

--- a/tests/ui/derive-not-on-enum.rs
+++ b/tests/ui/derive-not-on-enum.rs
@@ -1,0 +1,7 @@
+use arg_enum_proc_macro::ArgEnum;
+
+#[derive(ArgEnum)]
+pub struct Complicated {
+    pub foo: u8,
+    pub bar: u8,
+}

--- a/tests/ui/derive-not-on-enum.stderr
+++ b/tests/ui/derive-not-on-enum.stderr
@@ -1,0 +1,7 @@
+error: proc-macro derive panicked
+ --> $DIR/derive-not-on-enum.rs:3:10
+  |
+3 | #[derive(ArgEnum)]
+  |          ^^^^^^^
+  |
+  = help: message: Only enum supported


### PR DESCRIPTION
Hello @lu-zero,

While trying the macro I got confused by the error message I get when `#[derive(ArgEnum)]` is applied to "complex" enums.

I've splitted these changes in 2 commits:

 - 1st commit improves the error message
 - 2nd automates the tests for compile-time error reporting.
    I've used [trybuild](https://github.com/dtolnay/trybuild) (from the same author of `syn` and `quote`)  but I don't  know if you want this since it increases compile time a bit for tests.

 Thanks for this macro anyway!